### PR TITLE
Fix a problem when importing dives from UDDF dive log: Temperature field not recorded

### DIFF
--- a/app/models/divelog.rb
+++ b/app/models/divelog.rb
@@ -1240,7 +1240,7 @@ class Divelog
            
 
           temp = normalize_unit(s.xpath("TEMPERATURE").children.to_s.to_f, unit_temperature) unless s.xpath("TEMPERATURE").empty?
-          sample["current_water_temperature"] 
+          sample["current_water_temperature"] = temp
           temperature.push temp unless temp.nil?
 
 


### PR DESCRIPTION
When importing from a UDDF dive log file, the temperature samples are not properly initialized, therefore temperature detailed information is missing from the dive profile