### PR TITLE
Fix a problem on image gallery when no image URL is provided

### DIFF
--- a/app/assets/javascripts/modules/neat_gallery.js
+++ b/app/assets/javascripts/modules/neat_gallery.js
@@ -1,7 +1,6 @@
 (function($){
 
   $.fn.neat_gallery = function(argument) {
-	  console.log("START");
     var defaults = {
       source: dive_pictures_data,
       width: 400,

--- a/app/assets/javascripts/modules/neat_gallery.js
+++ b/app/assets/javascripts/modules/neat_gallery.js
@@ -1,7 +1,7 @@
 (function($){
 
   $.fn.neat_gallery = function(argument) {
-
+	  console.log("START");
     var defaults = {
       source: dive_pictures_data,
       width: 400,
@@ -195,11 +195,14 @@
 
     //add a picture at the end of the gallery
     var append = function(img){
+	  var url = img.image;
+	  if (img.image == null || img.image == '') {
+	  	url = "/img/picture_placeholder.png";
+	  }
       var idx = local_data.all_img.length;
 
       local_data.options.loading();
 
-      var url = img.image;
       var neobj = $("<img></img>");
       neobj.load(function(){
             var local_idx = idx;

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1230,7 +1230,7 @@ class Picture < ActiveRecord::Base
   end
 
   def self.generate_youtube_thumb id
-    return "http://img.youtube.com/vi/#{id.to_s}/default.jpg"
+    return "https://img.youtube.com/vi/#{id.to_s}/default.jpg"
     begin
       return JSON.parse(Net::HTTP.get URI.parse(jsoncall))["thumbnail_url"]
     rescue


### PR DESCRIPTION
When the system is not able to get a youtube video thumbnail URL, the "image" field of the neat_gallery is empty, leading to a crash in the gallery and the loader endlessly spinning.
2 fixes:
1) Root cause. Move the thumbnail collection to HTTPs
2) Effect fix. Add a default image when the image is empty so we can delete/fix it