### PR TITLE
Make password length limit fit visual hints

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -186,7 +186,7 @@ class SettingsController < ApplicationController
           return
         end
 
-        if new_pwd.length > 4 && new_pwd.length < 20 && new_pwd.match(/\ /).nil?
+        if new_pwd.length > 4 && new_pwd.length < 21 && new_pwd.match(/\ /).nil?
           ##new_pwd seems ok
           u.password = Password::update(new_pwd)
           u.save


### PR DESCRIPTION
The visual hints (green tick/red cross) suggest a 20 character password should be allowed (set here: https://github.com/Diveboard/diveboard-web/blob/master/app/views/settings/read.html.erb#L279) but the controller currently only actually allows 19 chars. 

Standardising on 20 here.